### PR TITLE
feat: [006-CUSTOMER-BALANCE] CUSTOMER에 대한 잔액 조회 구현

### DIFF
--- a/src/main/java/com/zerobase/cms/zerobasecms/controller/CustomerController.java
+++ b/src/main/java/com/zerobase/cms/zerobasecms/controller/CustomerController.java
@@ -1,18 +1,17 @@
 package com.zerobase.cms.zerobasecms.controller;
 
+import com.zerobase.cms.zerobasecms.domain.customer.ChangeBalanceForm;
 import com.zerobase.cms.zerobasecms.domain.customer.CustomerDto;
 import com.zerobase.cms.zerobasecms.domain.model.Customer;
 import com.zerobase.cms.zerobasecms.exception.CustomException;
 import com.zerobase.cms.zerobasecms.exception.ErrorCode;
+import com.zerobase.cms.zerobasecms.service.customer.CustomerBalanceService;
 import com.zerobase.cms.zerobasecms.service.customer.CustomerService;
 import com.zerobase.domain.config.JwtAuthenticationProvider;
 import com.zerobase.domain.domain.common.UserVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/customer")
@@ -21,7 +20,7 @@ public class CustomerController {
 
     private final JwtAuthenticationProvider provider;
     private final CustomerService customerService;
-
+    private final CustomerBalanceService customerBalanceService;
 
     @GetMapping("/getInfo")
     public ResponseEntity<CustomerDto> getInfo(@RequestHeader(name = "X-AUTH-TOKEN") String token){
@@ -31,5 +30,13 @@ public class CustomerController {
         );
 
         return ResponseEntity.ok(CustomerDto.from(c));
+    }
+
+    @PostMapping("/balance")
+    public ResponseEntity<Integer> changeBalance(@RequestHeader(name = "X-AUTH-TOKEN") String token,
+                                                 @RequestBody ChangeBalanceForm form){
+        UserVo vo = provider.getUser(token);
+
+        return ResponseEntity.ok(customerBalanceService.changeBalance(vo.getId(),form).getCurrentMoney());
     }
 }

--- a/src/main/java/com/zerobase/cms/zerobasecms/domain/customer/ChangeBalanceForm.java
+++ b/src/main/java/com/zerobase/cms/zerobasecms/domain/customer/ChangeBalanceForm.java
@@ -1,0 +1,11 @@
+package com.zerobase.cms.zerobasecms.domain.customer;
+
+import lombok.Getter;
+
+@Getter
+public class ChangeBalanceForm {
+    private String from;
+    private String message;
+    private Integer money;
+
+}

--- a/src/main/java/com/zerobase/cms/zerobasecms/domain/customer/CustomerDto.java
+++ b/src/main/java/com/zerobase/cms/zerobasecms/domain/customer/CustomerDto.java
@@ -12,9 +12,10 @@ public class CustomerDto {
 
     private Long id;
     private String email;
+    private Integer balance;
 
 
     public static CustomerDto from(Customer customer){
-        return new CustomerDto(customer.getId(),customer.getEmail());
+        return new CustomerDto(customer.getId(),customer.getEmail(), customer.getBalance()==null?0: customer.getBalance());
     }
 }

--- a/src/main/java/com/zerobase/cms/zerobasecms/domain/model/Customer.java
+++ b/src/main/java/com/zerobase/cms/zerobasecms/domain/model/Customer.java
@@ -33,6 +33,9 @@ public class Customer extends BaseEntity{
     private String verificationCode;
     private boolean verify;
 
+    @Column(columnDefinition = "int default 0")
+    private Integer balance;
+
     public static Customer from(SignUpForm form){
         return Customer.builder()
                 .email(form.getEmail().toLowerCase(Locale.ROOT))

--- a/src/main/java/com/zerobase/cms/zerobasecms/domain/model/CustomerBalanceHistory.java
+++ b/src/main/java/com/zerobase/cms/zerobasecms/domain/model/CustomerBalanceHistory.java
@@ -1,0 +1,27 @@
+package com.zerobase.cms.zerobasecms.domain.model;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerBalanceHistory extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(targetEntity = Customer.class, fetch = FetchType.LAZY)
+    private Customer customer;
+
+    private Integer changeMoney;
+
+    private Integer currentMoney;
+
+    private String fromMessage;
+    private String description;
+}

--- a/src/main/java/com/zerobase/cms/zerobasecms/domain/repository/CustomerBalanceHistoryRepository.java
+++ b/src/main/java/com/zerobase/cms/zerobasecms/domain/repository/CustomerBalanceHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.cms.zerobasecms.domain.repository;
+
+import com.zerobase.cms.zerobasecms.domain.model.CustomerBalanceHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Optional;
+
+public interface CustomerBalanceHistoryRepository extends JpaRepository<CustomerBalanceHistory,Long> {
+
+    Optional<CustomerBalanceHistory> findFirstByCustomer_idOrderByIdDesc(@RequestParam("customer_id") Long customerId);
+}

--- a/src/main/java/com/zerobase/cms/zerobasecms/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/cms/zerobasecms/exception/ErrorCode.java
@@ -15,8 +15,9 @@ public enum ErrorCode {
     //login
     LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST,"아이디나 패스워드를 확인해주세요."),
 
-    ALREADY_VERIFIED(HttpStatus.BAD_REQUEST,"이미 인증이 완료되었습니다.");
+    ALREADY_VERIFIED(HttpStatus.BAD_REQUEST,"이미 인증이 완료되었습니다."),
 
+    NOT_ENOUGH_BALANCE(HttpStatus.BAD_REQUEST,"잔액이 부족합니다.");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/com/zerobase/cms/zerobasecms/service/customer/CustomerBalanceService.java
+++ b/src/main/java/com/zerobase/cms/zerobasecms/service/customer/CustomerBalanceService.java
@@ -1,0 +1,47 @@
+package com.zerobase.cms.zerobasecms.service.customer;
+
+import com.zerobase.cms.zerobasecms.domain.customer.ChangeBalanceForm;
+import com.zerobase.cms.zerobasecms.domain.model.CustomerBalanceHistory;
+import com.zerobase.cms.zerobasecms.domain.repository.CustomerBalanceHistoryRepository;
+import com.zerobase.cms.zerobasecms.domain.repository.CustomerRepository;
+import com.zerobase.cms.zerobasecms.exception.CustomException;
+import com.zerobase.cms.zerobasecms.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerBalanceService {
+
+    private final CustomerBalanceHistoryRepository customerBalanceHistoryRepository;
+    private final CustomerRepository customerRepository;
+
+    @Transactional(noRollbackFor = {CustomException.class})
+    public CustomerBalanceHistory changeBalance(Long customerId, ChangeBalanceForm form)
+            throws CustomException {
+        CustomerBalanceHistory customerBalanceHistory =
+                customerBalanceHistoryRepository.findFirstByCustomer_idOrderByIdDesc(customerId)
+                        .orElse(CustomerBalanceHistory.builder()
+                                .changeMoney(0)
+                                .currentMoney(0)
+                                .customer(customerRepository.findById(customerId)
+                                        .orElseThrow(() -> new CustomException(ErrorCode.UNREGISTERED_USER)))
+                                .build());
+        if (customerBalanceHistory.getChangeMoney() + form.getMoney() < 0) {
+            throw new CustomException(ErrorCode.NOT_ENOUGH_BALANCE);
+        }
+
+        customerBalanceHistory = CustomerBalanceHistory.builder()
+                .changeMoney(form.getMoney())
+                .currentMoney(customerBalanceHistory.getCurrentMoney()+form.getMoney())
+                .description(form.getMessage())
+                .fromMessage(form.getFrom())
+                .customer(customerBalanceHistory.getCustomer())
+                .build();
+
+        customerBalanceHistory.getCustomer().setBalance(customerBalanceHistory.getCurrentMoney());
+
+        return customerBalanceHistory;
+    }
+}


### PR DESCRIPTION
Changes
---
1. ChangeBalance method 추가
1-1.  ChangeBalanceForm을 통해서 변화 금액을 받으면 현재 customer의 balance를 조회하고 그 금액에다가 변화 금액을 반영 후 저장한다.
1-2. 잔액이 부족할 경우, 동작을 취소한다.

2. 그에 따라 필요한 CustomerBalanceHistory, CustomerBalanceHistoryRepo, ChangeBalanceForm 추가